### PR TITLE
No more flashing items from Quark ASM Patch

### DIFF
--- a/config/quark.cfg
+++ b/config/quark.cfg
@@ -346,7 +346,7 @@ client {
     B:"Greener grass"=true
     B:"Improved mount h u d"=true
     B:"Improved sign edit"=true
-    B:"Items flash before expiring"=true
+    B:"Items flash before expiring"=false
     B:"Less intrusive shields"=true
     B:"Map tooltip"=true
     B:"No potion shift"=true


### PR DESCRIPTION
Because this is ridiculous.

Tons of dropped items (entity) flashing, will eat all resources.